### PR TITLE
Remove unneeded + broken build tag

### DIFF
--- a/and_arm64.go
+++ b/and_arm64.go
@@ -1,4 +1,3 @@
-// go:build arm64
 package and
 
 //go:noescape


### PR DESCRIPTION
They only work without the space between // and go:build

but it's implied because of the filename anyway