### PR TITLE
CI: bump Go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
We need at least 1.22 for math/rand/v2