### PR TITLE
Add Memset()

### DIFF
--- a/and_amd64.go
+++ b/and_amd64.go
@@ -49,3 +49,15 @@ func popcnt(a []byte) int {
 	ret += popcntGeneric(a[l:])
 	return ret
 }
+
+func memset(dst []byte, b byte) {
+	l := uint64(0)
+	if hasAVX2() {
+		l = uint64(len(dst)) >> 5
+		if l != 0 {
+			memsetAVX2(&dst[0], l, b)
+		}
+		l <<= 5
+	}
+	memsetGeneric(dst[l:], b)
+}

--- a/and_amd64.s
+++ b/and_amd64.s
@@ -183,3 +183,17 @@ loop:
 	JNZ     loop
 	MOVQ    DX, ret+16(FP)
 	RET
+
+// func memsetAVX2(dst *byte, l uint64, b byte)
+// Requires: AVX, AVX2
+TEXT ·memsetAVX2(SB), NOSPLIT, $0-17
+	MOVQ         dst+0(FP), AX
+	MOVQ         l+8(FP), CX
+	VPBROADCASTB b+16(FP), Y0
+
+loop:
+	VMOVDQU Y0, (AX)
+	ADDQ    $0x00000020, AX
+	SUBQ    $0x00000001, CX
+	JNZ     loop
+	RET

--- a/and_arm64.go
+++ b/and_arm64.go
@@ -33,3 +33,8 @@ func popcnt(a []byte) int {
 	// TODO: Write a NEON version for this
 	return popcntGeneric(a)
 }
+
+func memset(dst []byte, b byte) {
+	// TODO: Write a NEON version for this
+	memsetGeneric(dst, b)
+}

--- a/and_stubs_amd64.go
+++ b/and_stubs_amd64.go
@@ -21,3 +21,8 @@ func andNotAVX2(dst *byte, a *byte, b *byte, l uint64)
 //
 //go:noescape
 func popcntAsm(a *byte, l uint64) int
+
+// Sets each byte in dst to b
+//
+//go:noescape
+func memsetAVX2(dst *byte, l uint64, b byte)

--- a/fallback.go
+++ b/fallback.go
@@ -17,3 +17,7 @@ func andNot(dst, a, b []byte) {
 func popcnt(a []byte) int {
 	return popcntGeneric(a)
 }
+
+func memset(dst []byte, b byte) {
+	return memsetGeneric(dst, b)
+}

--- a/lib.go
+++ b/lib.go
@@ -104,3 +104,14 @@ func popcntGeneric(a []byte) int {
 	}
 	return ret
 }
+
+// Memset sets dst[*] to b.
+func Memset(dst []byte, b byte) {
+	memset(dst, b)
+}
+
+func memsetGeneric(dst []byte, b byte) {
+	for i := range dst {
+		dst[i] = b
+	}
+}

--- a/memset_test.go
+++ b/memset_test.go
@@ -1,0 +1,48 @@
+package and
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+func testMemset(t *testing.T, size int) {
+	a := make([]byte, size)
+	Memset(a, 0xff)
+	for i, v := range a {
+		if v != 0xff {
+			t.Errorf("Memset failed to set a[%d] to 0xff", i)
+		}
+	}
+}
+
+func TestMemsetAgainstGeneric(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		size := 1 << i
+		testMemset(t, size)
+		for j := 0; j < 10; j++ {
+			testMemset(t, size+rand.IntN(100))
+		}
+	}
+}
+
+func BenchmarkMemset(b *testing.B) {
+	b.StopTimer()
+	size := 1000000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		Memset(a, 0xff)
+	}
+}
+
+func BenchmarkMemsetGeneric(b *testing.B) {
+	b.StopTimer()
+	size := 1000000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		memsetGeneric(a, 0xff)
+	}
+}


### PR DESCRIPTION
10x faster than a naive loop

```
$ go test -bench=Memset
goos: linux
goarch: amd64
pkg: github.com/bwesterb/go-and
cpu: 13th Gen Intel(R) Core(TM) i9-13900
BenchmarkMemset-32           	   73898	     15965 ns/op	62637.75 MB/s
BenchmarkMemsetGeneric-32    	    6602	    168255 ns/op	5943.36 MB/s
```