### PR TITLE
Add a script to benchmark and add to the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Benchmark output files
+asm
+naive
+purego

--- a/README.md
+++ b/README.md
@@ -17,3 +17,37 @@ func main() {
 ```
 
 Makes use of AVX2 on AMD64 and NEON on ARM64.
+
+## Benchmarks
+
+Created using `./benchmark.sh`.
+
+This shows three benchmarks:
+
+* `naive` is a simple for loop doing one byte at a time.
+* `purego` are our slightly optimized versions that work on uint64s instead of bytes.
+* `asm` are the AVX2 implementations and the reason to use this library.
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/bwesterb/go-and
+cpu: 13th Gen Intel(R) Core(TM) i9-13900
+          │    naive     │                purego                │                 asm                 │
+          │    sec/op    │    sec/op     vs base                │   sec/op     vs base                │
+And-32      273.05µ ± 5%    64.48µ ± 2%  -76.39% (p=0.000 n=10)   21.88µ ± 1%  -91.99% (p=0.000 n=10)
+Or-32       274.70µ ± 6%    64.36µ ± 1%  -76.57% (p=0.000 n=10)   21.81µ ± 1%  -92.06% (p=0.000 n=10)
+AndNot-32   310.78µ ± 2%    71.01µ ± 2%  -77.15% (p=0.000 n=10)   21.83µ ± 1%  -92.98% (p=0.000 n=10)
+Memset-32   167.77µ ± 0%   167.55µ ± 0%   -0.13% (p=0.002 n=10)   15.88µ ± 1%  -90.53% (p=0.000 n=10)
+Popcnt-32   126.84µ ± 0%    71.42µ ± 1%  -43.69% (p=0.000 n=10)   32.48µ ± 1%  -74.40% (p=0.000 n=10)
+geomean      218.3µ         81.18µ       -62.82%                  22.18µ       -89.84%
+
+          │    naive     │                 purego                 │                   asm                   │
+          │     B/s      │      B/s       vs base                 │      B/s       vs base                  │
+And-32      3.411Gi ± 5%   14.444Gi ± 2%  +323.45% (p=0.000 n=10)   42.560Gi ± 1%  +1147.72% (p=0.000 n=10)
+Or-32       3.391Gi ± 7%   14.470Gi ± 1%  +326.78% (p=0.000 n=10)   42.708Gi ± 1%  +1159.61% (p=0.000 n=10)
+AndNot-32   2.997Gi ± 2%   13.116Gi ± 2%  +337.68% (p=0.000 n=10)   42.665Gi ± 1%  +1323.72% (p=0.000 n=10)
+Memset-32   5.551Gi ± 0%    5.559Gi ± 0%    +0.13% (p=0.002 n=10)   58.642Gi ± 1%   +956.36% (p=0.000 n=10)
+Popcnt-32   7.342Gi ± 0%   13.040Gi ± 1%   +77.60% (p=0.000 n=10)   28.677Gi ± 1%   +290.57% (p=0.000 n=10)
+geomean     4.266Gi         11.47Gi       +168.93%                   41.98Gi        +884.14%
+```

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+# ^.{2,6}$ is a hack to skip the .+Generic benchmarks
+go test -run=^# -count=10 -bench="^Benchmark.{2,6}$" | tee asm
+go test -run=^# -count=10 -bench="^Benchmark.{2,6}$" -tags purego | tee purego
+go test -run=^# -count=10 -bench="^Benchmark.{2,6}Naive$" | sed --unbuffered 's/Naive//g' | tee naive
+go run golang.org/x/perf/cmd/benchstat@latest naive purego asm

--- a/memset_test.go
+++ b/memset_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+func memsetNaive(dst []byte, b byte) {
+	for i := range dst {
+		dst[i] = b
+	}
+}
+
 func testMemset(t *testing.T, size int) {
 	a := make([]byte, size)
 	Memset(a, 0xff)
@@ -44,5 +50,16 @@ func BenchmarkMemsetGeneric(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		memsetGeneric(a, 0xff)
+	}
+}
+
+func BenchmarkMemsetNaive(b *testing.B) {
+	b.StopTimer()
+	size := 1000000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		memsetNaive(a, 0xff)
 	}
 }

--- a/popcnt_test.go
+++ b/popcnt_test.go
@@ -1,9 +1,18 @@
 package and
 
 import (
+	"math/bits"
 	"math/rand/v2"
 	"testing"
 )
+
+func popcntNaive(a []byte) int {
+	var ret int
+	for i := range a {
+		ret += bits.OnesCount8(a[i])
+	}
+	return ret
+}
 
 func testPopcntAgainstGeneric(t *testing.T, size int) {
 	a := make([]byte, size)
@@ -47,5 +56,16 @@ func BenchmarkPopcntGeneric(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		_ = popcntGeneric(a)
+	}
+}
+
+func BenchmarkPopcntNaive(b *testing.B) {
+	b.StopTimer()
+	size := 1000000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = popcntNaive(a)
 	}
 }


### PR DESCRIPTION
I wanted to benchmark the naive implementations to show the difference even our generic(/purego) implementations make. I also used them as the comparisons for our tests, as they're even less likely to have bugs.