### PR TITLE
feat: add AnyMasked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Benchmark output files
-asm
-naive
-purego
+/asm
+/naive
+/purego

--- a/and_amd64.go
+++ b/and_amd64.go
@@ -124,20 +124,20 @@ func memset(dst []byte, b byte) {
 	memsetGeneric(dst[l:], b)
 }
 
-func anySetMasked(a, b []byte) bool {
+func anyMasked(a, b []byte) bool {
 	l := uint64(0)
 	if hasAVX2() {
 		l = uint64(len(a)) >> 8
-		if l != 0 && anySetMaskedAVX2(&a[0], &b[0], l) {
+		if l != 0 && anyMaskedAVX2(&a[0], &b[0], l) {
 			return true
 		}
 		l <<= 8
 	} else if hasAVX() {
 		l = uint64(len(a)) >> 7
-		if l != 0 && anySetMaskedAVX(&a[0], &b[0], l) {
+		if l != 0 && anyMaskedAVX(&a[0], &b[0], l) {
 			return true
 		}
 		l <<= 7
 	}
-	return anySetMaskedGeneric(a[l:], b[l:])
+	return anyMaskedGeneric(a[l:], b[l:])
 }

--- a/and_amd64.go
+++ b/and_amd64.go
@@ -126,18 +126,12 @@ func memset(dst []byte, b byte) {
 
 func anyMasked(a, b []byte) bool {
 	l := uint64(0)
-	if hasAVX2() {
+	if hasAVX() {
 		l = uint64(len(a)) >> 8
-		if l != 0 && anyMaskedAVX2(&a[0], &b[0], l) {
-			return true
-		}
-		l <<= 8
-	} else if hasAVX() {
-		l = uint64(len(a)) >> 7
 		if l != 0 && anyMaskedAVX(&a[0], &b[0], l) {
 			return true
 		}
-		l <<= 7
+		l <<= 8
 	}
 	return anyMaskedGeneric(a[l:], b[l:])
 }

--- a/and_amd64.go
+++ b/and_amd64.go
@@ -123,3 +123,21 @@ func memset(dst []byte, b byte) {
 	}
 	memsetGeneric(dst[l:], b)
 }
+
+func anySetMasked(a, b []byte) bool {
+	l := uint64(0)
+	if hasAVX2() {
+		l = uint64(len(a)) >> 8
+		if l != 0 && anySetMaskedAVX2(&a[0], &b[0], l) {
+			return true
+		}
+		l <<= 8
+	} else if hasAVX() {
+		l = uint64(len(a)) >> 7
+		if l != 0 && anySetMaskedAVX(&a[0], &b[0], l) {
+			return true
+		}
+		l <<= 7
+	}
+	return anySetMaskedGeneric(a[l:], b[l:])
+}

--- a/and_amd64.s
+++ b/and_amd64.s
@@ -556,9 +556,9 @@ DATA zeroes<>+8(SB)/4, $0x00000000
 DATA zeroes<>+12(SB)/4, $0x00000000
 GLOBL zeroes<>(SB), RODATA|NOPTR, $16
 
-// func anyMaskedAVX2(a *byte, b *byte, l uint64) bool
+// func anyMaskedAVX(a *byte, b *byte, l uint64) bool
 // Requires: AVX
-TEXT ·anyMaskedAVX2(SB), NOSPLIT, $0-25
+TEXT ·anyMaskedAVX(SB), NOSPLIT, $0-25
 	MOVQ a+0(FP), AX
 	MOVQ b+8(FP), CX
 	MOVQ l+16(FP), DX
@@ -598,59 +598,6 @@ loop:
 	JNZ     found
 	ADDQ    $0x00000100, AX
 	ADDQ    $0x00000100, CX
-	SUBQ    $0x00000001, DX
-	JNZ     loop
-	MOVL    $0x00000000, AX
-	VZEROALL
-	RET
-
-found:
-	MOVL $0x00000001, AX
-	VZEROALL
-	RET
-
-// func anyMaskedAVX(a *byte, b *byte, l uint64) bool
-// Requires: AVX
-TEXT ·anyMaskedAVX(SB), NOSPLIT, $0-25
-	MOVQ a+0(FP), AX
-	MOVQ b+8(FP), CX
-	MOVQ l+16(FP), DX
-
-loop:
-	VMOVDQU (AX), X0
-	VMOVDQU (CX), X1
-	VMOVDQU 16(AX), X2
-	VMOVDQU 16(CX), X3
-	VMOVDQU 32(AX), X4
-	VMOVDQU 32(CX), X5
-	VMOVDQU 48(AX), X6
-	VMOVDQU 48(CX), X7
-	VMOVDQU 64(AX), X8
-	VMOVDQU 64(CX), X9
-	VMOVDQU 80(AX), X10
-	VMOVDQU 80(CX), X11
-	VMOVDQU 96(AX), X12
-	VMOVDQU 96(CX), X13
-	VMOVDQU 112(AX), X14
-	VMOVDQU 112(CX), X15
-	VPTEST  X0, X1
-	JNZ     found
-	VPTEST  X2, X3
-	JNZ     found
-	VPTEST  X4, X5
-	JNZ     found
-	VPTEST  X6, X7
-	JNZ     found
-	VPTEST  X8, X9
-	JNZ     found
-	VPTEST  X10, X11
-	JNZ     found
-	VPTEST  X12, X13
-	JNZ     found
-	VPTEST  X14, X15
-	JNZ     found
-	ADDQ    $0x00000080, AX
-	ADDQ    $0x00000080, CX
 	SUBQ    $0x00000001, DX
 	JNZ     loop
 	MOVL    $0x00000000, AX

--- a/and_amd64.s
+++ b/and_amd64.s
@@ -555,3 +555,109 @@ DATA zeroes<>+4(SB)/4, $0x00000000
 DATA zeroes<>+8(SB)/4, $0x00000000
 DATA zeroes<>+12(SB)/4, $0x00000000
 GLOBL zeroes<>(SB), RODATA|NOPTR, $16
+
+// func anySetMaskedAVX2(a *byte, b *byte, l uint64) bool
+// Requires: AVX
+TEXT ·anySetMaskedAVX2(SB), NOSPLIT, $0-25
+	MOVQ a+0(FP), AX
+	MOVQ b+8(FP), CX
+	MOVQ l+16(FP), DX
+
+loop:
+	VMOVDQU (AX), Y0
+	VMOVDQU (CX), Y1
+	VMOVDQU 32(AX), Y2
+	VMOVDQU 32(CX), Y3
+	VMOVDQU 64(AX), Y4
+	VMOVDQU 64(CX), Y5
+	VMOVDQU 96(AX), Y6
+	VMOVDQU 96(CX), Y7
+	VMOVDQU 128(AX), Y8
+	VMOVDQU 128(CX), Y9
+	VMOVDQU 160(AX), Y10
+	VMOVDQU 160(CX), Y11
+	VMOVDQU 192(AX), Y12
+	VMOVDQU 192(CX), Y13
+	VMOVDQU 224(AX), Y14
+	VMOVDQU 224(CX), Y15
+	VPTEST  Y0, Y1
+	JNZ     found
+	VPTEST  Y2, Y3
+	JNZ     found
+	VPTEST  Y4, Y5
+	JNZ     found
+	VPTEST  Y6, Y7
+	JNZ     found
+	VPTEST  Y8, Y9
+	JNZ     found
+	VPTEST  Y10, Y11
+	JNZ     found
+	VPTEST  Y12, Y13
+	JNZ     found
+	VPTEST  Y14, Y15
+	JNZ     found
+	ADDQ    $0x00000100, AX
+	ADDQ    $0x00000100, CX
+	SUBQ    $0x00000001, DX
+	JNZ     loop
+	MOVL    $0x00000000, AX
+	VZEROALL
+	RET
+
+found:
+	MOVL $0x00000001, AX
+	VZEROALL
+	RET
+
+// func anySetMaskedAVX(a *byte, b *byte, l uint64) bool
+// Requires: AVX
+TEXT ·anySetMaskedAVX(SB), NOSPLIT, $0-25
+	MOVQ a+0(FP), AX
+	MOVQ b+8(FP), CX
+	MOVQ l+16(FP), DX
+
+loop:
+	VMOVDQU (AX), X0
+	VMOVDQU (CX), X1
+	VMOVDQU 16(AX), X2
+	VMOVDQU 16(CX), X3
+	VMOVDQU 32(AX), X4
+	VMOVDQU 32(CX), X5
+	VMOVDQU 48(AX), X6
+	VMOVDQU 48(CX), X7
+	VMOVDQU 64(AX), X8
+	VMOVDQU 64(CX), X9
+	VMOVDQU 80(AX), X10
+	VMOVDQU 80(CX), X11
+	VMOVDQU 96(AX), X12
+	VMOVDQU 96(CX), X13
+	VMOVDQU 112(AX), X14
+	VMOVDQU 112(CX), X15
+	VPTEST  X0, X1
+	JNZ     found
+	VPTEST  X2, X3
+	JNZ     found
+	VPTEST  X4, X5
+	JNZ     found
+	VPTEST  X6, X7
+	JNZ     found
+	VPTEST  X8, X9
+	JNZ     found
+	VPTEST  X10, X11
+	JNZ     found
+	VPTEST  X12, X13
+	JNZ     found
+	VPTEST  X14, X15
+	JNZ     found
+	ADDQ    $0x00000080, AX
+	ADDQ    $0x00000080, CX
+	SUBQ    $0x00000001, DX
+	JNZ     loop
+	MOVL    $0x00000000, AX
+	VZEROALL
+	RET
+
+found:
+	MOVL $0x00000001, AX
+	VZEROALL
+	RET

--- a/and_amd64.s
+++ b/and_amd64.s
@@ -600,11 +600,13 @@ loop:
 	ADDQ    $0x00000100, CX
 	SUBQ    $0x00000001, DX
 	JNZ     loop
-	MOVL    $0x00000000, AX
+	XORB    AL, AL
+	MOVB    AL, ret+24(FP)
 	VZEROALL
 	RET
 
 found:
-	MOVL $0x00000001, AX
+	MOVB $0x01, AL
+	MOVB AL, ret+24(FP)
 	VZEROALL
 	RET

--- a/and_amd64.s
+++ b/and_amd64.s
@@ -556,9 +556,9 @@ DATA zeroes<>+8(SB)/4, $0x00000000
 DATA zeroes<>+12(SB)/4, $0x00000000
 GLOBL zeroes<>(SB), RODATA|NOPTR, $16
 
-// func anySetMaskedAVX2(a *byte, b *byte, l uint64) bool
+// func anyMaskedAVX2(a *byte, b *byte, l uint64) bool
 // Requires: AVX
-TEXT ·anySetMaskedAVX2(SB), NOSPLIT, $0-25
+TEXT ·anyMaskedAVX2(SB), NOSPLIT, $0-25
 	MOVQ a+0(FP), AX
 	MOVQ b+8(FP), CX
 	MOVQ l+16(FP), DX
@@ -609,9 +609,9 @@ found:
 	VZEROALL
 	RET
 
-// func anySetMaskedAVX(a *byte, b *byte, l uint64) bool
+// func anyMaskedAVX(a *byte, b *byte, l uint64) bool
 // Requires: AVX
-TEXT ·anySetMaskedAVX(SB), NOSPLIT, $0-25
+TEXT ·anyMaskedAVX(SB), NOSPLIT, $0-25
 	MOVQ a+0(FP), AX
 	MOVQ b+8(FP), CX
 	MOVQ l+16(FP), DX

--- a/and_arm64.go
+++ b/and_arm64.go
@@ -78,3 +78,8 @@ func memset(dst []byte, b byte) {
 	l <<= 8
 	memsetGeneric(dst[l:], b)
 }
+
+func anySetMasked(a, b []byte) bool {
+	// TODO: Write NEON implementation
+	return anySetMaskedGeneric(a, b)
+}

--- a/and_arm64.go
+++ b/and_arm64.go
@@ -79,7 +79,7 @@ func memset(dst []byte, b byte) {
 	memsetGeneric(dst[l:], b)
 }
 
-func anySetMasked(a, b []byte) bool {
+func anyMasked(a, b []byte) bool {
 	// TODO: Write NEON implementation
-	return anySetMaskedGeneric(a, b)
+	return anyMaskedGeneric(a, b)
 }

--- a/and_stubs_amd64.go
+++ b/and_stubs_amd64.go
@@ -72,9 +72,4 @@ func memsetAVX(dst *byte, l uint64, b byte)
 // Returns whether any of the bits of the bitwise and of a and b are set assuming all are 256*l bytes
 //
 //go:noescape
-func anyMaskedAVX2(a *byte, b *byte, l uint64) bool
-
-// Returns whether any of the bits of the bitwise and of a and b are set assuming all are 128*l bytes
-//
-//go:noescape
 func anyMaskedAVX(a *byte, b *byte, l uint64) bool

--- a/and_stubs_amd64.go
+++ b/and_stubs_amd64.go
@@ -68,3 +68,13 @@ func memsetAVX2(dst *byte, l uint64, b byte)
 //
 //go:noescape
 func memsetAVX(dst *byte, l uint64, b byte)
+
+// Returns whether any of the bits of the bitwise and of a and b are set assuming all are 256*l bytes
+//
+//go:noescape
+func anySetMaskedAVX2(a *byte, b *byte, l uint64) bool
+
+// Returns whether any of the bits of the bitwise and of a and b are set assuming all are 128*l bytes
+//
+//go:noescape
+func anySetMaskedAVX(a *byte, b *byte, l uint64) bool

--- a/and_stubs_amd64.go
+++ b/and_stubs_amd64.go
@@ -72,9 +72,9 @@ func memsetAVX(dst *byte, l uint64, b byte)
 // Returns whether any of the bits of the bitwise and of a and b are set assuming all are 256*l bytes
 //
 //go:noescape
-func anySetMaskedAVX2(a *byte, b *byte, l uint64) bool
+func anyMaskedAVX2(a *byte, b *byte, l uint64) bool
 
 // Returns whether any of the bits of the bitwise and of a and b are set assuming all are 128*l bytes
 //
 //go:noescape
-func anySetMaskedAVX(a *byte, b *byte, l uint64) bool
+func anyMaskedAVX(a *byte, b *byte, l uint64) bool

--- a/and_test.go
+++ b/and_test.go
@@ -32,7 +32,7 @@ func andNotNaive(dst, a, b []byte) {
 	}
 }
 
-func anySetMaskedNaive(a, b []byte) bool {
+func anyMaskedNaive(a, b []byte) bool {
 	for i := range a {
 		if a[i]&b[i] != 0 {
 			return true
@@ -121,14 +121,14 @@ func TestAndNot(t *testing.T) {
 	}
 }
 
-func TestAnySetMasked(t *testing.T) {
+func TestAnyMasked(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		size := 1 << i
-		testAgainstBool(t, AnySetMasked, anySetMaskedNaive, size)
-		testAgainstBool(t, anySetMaskedGeneric, anySetMaskedNaive, size)
+		testAgainstBool(t, AnyMasked, anyMaskedNaive, size)
+		testAgainstBool(t, anyMaskedGeneric, anyMaskedNaive, size)
 		for j := 0; j < 10; j++ {
-			testAgainstBool(t, AnySetMasked, anySetMaskedNaive, size+rand.IntN(100))
-			testAgainstBool(t, anySetMaskedGeneric, anySetMaskedNaive, size+rand.IntN(100))
+			testAgainstBool(t, AnyMasked, anyMaskedNaive, size+rand.IntN(100))
+			testAgainstBool(t, anyMaskedGeneric, anyMaskedNaive, size+rand.IntN(100))
 		}
 	}
 }
@@ -277,7 +277,7 @@ func BenchmarkAndNotNaive(b *testing.B) {
 	}
 }
 
-func BenchmarkAnySetMasked(b *testing.B) {
+func BenchmarkAnyMasked(b *testing.B) {
 	b.StopTimer()
 	size := 32000
 	a := make([]byte, size)
@@ -285,11 +285,11 @@ func BenchmarkAnySetMasked(b *testing.B) {
 	b.SetBytes(int64(size))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		AnySetMasked(a, bb)
+		AnyMasked(a, bb)
 	}
 }
 
-func BenchmarkAnySetMaskedGeneric(b *testing.B) {
+func BenchmarkAnyMaskedGeneric(b *testing.B) {
 	b.StopTimer()
 	size := 32000
 	a := make([]byte, size)
@@ -297,11 +297,11 @@ func BenchmarkAnySetMaskedGeneric(b *testing.B) {
 	b.SetBytes(int64(size))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		anySetMaskedGeneric(a, bb)
+		anyMaskedGeneric(a, bb)
 	}
 }
 
-func BenchmarkAnySetMaskedNaive(b *testing.B) {
+func BenchmarkAnyMaskedNaive(b *testing.B) {
 	b.StopTimer()
 	size := 32000
 	a := make([]byte, size)
@@ -309,6 +309,6 @@ func BenchmarkAnySetMaskedNaive(b *testing.B) {
 	b.SetBytes(int64(size))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		anySetMaskedNaive(a, bb)
+		anyMaskedNaive(a, bb)
 	}
 }

--- a/and_test.go
+++ b/and_test.go
@@ -32,15 +32,6 @@ func andNotNaive(dst, a, b []byte) {
 	}
 }
 
-func anyMaskedNaive(a, b []byte) bool {
-	for i := range a {
-		if a[i]&b[i] != 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func createRandomBuffer(size int) []byte {
 	ret := make([]byte, size)
 	rng := rand.New(rand.NewPCG(rand.Uint64(), 0))
@@ -59,19 +50,6 @@ func testAgainst(t *testing.T, fancy, generic func(dst, a, b []byte), size int) 
 	generic(c2, a, b)
 	if !bytes.Equal(c1, c2) {
 		t.Fatalf("%s produced a different result from %s at length %d:\n%x\n%x", runtime.FuncForPC(reflect.ValueOf(fancy).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(generic).Pointer()).Name(), size, c1, c2)
-	}
-}
-
-func testAgainstBool(t *testing.T, fancy, generic func(a, b []byte) bool, size int) {
-	a := make([]byte, size)
-	b := make([]byte, size)
-	idx := rand.IntN(size)
-	a[idx] = uint8(rand.Uint())
-	b[idx] = uint8(rand.Uint())
-	r1 := fancy(a, b)
-	r2 := generic(a, b)
-	if r1 != r2 {
-		t.Fatalf("%s produced a different result from %s at length %d:\n%t\n%t", runtime.FuncForPC(reflect.ValueOf(fancy).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(generic).Pointer()).Name(), size, r1, r2)
 	}
 }
 
@@ -119,18 +97,6 @@ func TestAndNot(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			testAgainst(t, AndNot, andNotNaive, size+rand.IntN(100))
 			testAgainst(t, andNotGeneric, andNotNaive, size+rand.IntN(100))
-		}
-	}
-}
-
-func TestAnyMasked(t *testing.T) {
-	for i := 0; i < 20; i++ {
-		size := 1 << i
-		testAgainstBool(t, AnyMasked, anyMaskedNaive, size)
-		testAgainstBool(t, anyMaskedGeneric, anyMaskedNaive, size)
-		for j := 0; j < 10; j++ {
-			testAgainstBool(t, AnyMasked, anyMaskedNaive, size+rand.IntN(100))
-			testAgainstBool(t, anyMaskedGeneric, anyMaskedNaive, size+rand.IntN(100))
 		}
 	}
 }
@@ -276,41 +242,5 @@ func BenchmarkAndNotNaive(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		andNotNaive(a, a, bb)
-	}
-}
-
-func BenchmarkAnyMasked(b *testing.B) {
-	b.StopTimer()
-	size := 32000
-	a := make([]byte, size)
-	bb := make([]byte, size)
-	b.SetBytes(int64(size))
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		AnyMasked(a, bb)
-	}
-}
-
-func BenchmarkAnyMaskedGeneric(b *testing.B) {
-	b.StopTimer()
-	size := 32000
-	a := make([]byte, size)
-	bb := make([]byte, size)
-	b.SetBytes(int64(size))
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		anyMaskedGeneric(a, bb)
-	}
-}
-
-func BenchmarkAnyMaskedNaive(b *testing.B) {
-	b.StopTimer()
-	size := 32000
-	a := make([]byte, size)
-	bb := make([]byte, size)
-	b.SetBytes(int64(size))
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		anyMaskedNaive(a, bb)
 	}
 }

--- a/and_test.go
+++ b/and_test.go
@@ -280,8 +280,8 @@ func BenchmarkAndNotNaive(b *testing.B) {
 func BenchmarkAnySetMasked(b *testing.B) {
 	b.StopTimer()
 	size := 32000
-	a := createRandomBuffer(size)
-	bb := createRandomBuffer(size)
+	a := make([]byte, size)
+	bb := make([]byte, size)
 	b.SetBytes(int64(size))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -292,8 +292,8 @@ func BenchmarkAnySetMasked(b *testing.B) {
 func BenchmarkAnySetMaskedGeneric(b *testing.B) {
 	b.StopTimer()
 	size := 32000
-	a := createRandomBuffer(size)
-	bb := createRandomBuffer(size)
+	a := make([]byte, size)
+	bb := make([]byte, size)
 	b.SetBytes(int64(size))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -304,8 +304,8 @@ func BenchmarkAnySetMaskedGeneric(b *testing.B) {
 func BenchmarkAnySetMaskedNaive(b *testing.B) {
 	b.StopTimer()
 	size := 32000
-	a := createRandomBuffer(size)
-	bb := createRandomBuffer(size)
+	a := make([]byte, size)
+	bb := make([]byte, size)
 	b.SetBytes(int64(size))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {

--- a/and_test.go
+++ b/and_test.go
@@ -63,14 +63,16 @@ func testAgainst(t *testing.T, fancy, generic func(dst, a, b []byte), size int) 
 }
 
 func testAgainstBool(t *testing.T, fancy, generic func(a, b []byte) bool, size int) {
-	a := createRandomBuffer(size)
-	b := createRandomBuffer(size)
+	a := make([]byte, size)
+	b := make([]byte, size)
+	idx := rand.IntN(size)
+	a[idx] = uint8(rand.Uint())
+	b[idx] = uint8(rand.Uint())
 	r1 := fancy(a, b)
 	r2 := generic(a, b)
 	if r1 != r2 {
 		t.Fatalf("%s produced a different result from %s at length %d:\n%t\n%t", runtime.FuncForPC(reflect.ValueOf(fancy).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(generic).Pointer()).Name(), size, r1, r2)
 	}
-
 }
 
 func TestAnd(t *testing.T) {

--- a/any_masked_test.go
+++ b/any_masked_test.go
@@ -20,8 +20,8 @@ func testAgainstBool(t *testing.T, fancy, generic func(a, b []byte) bool, size i
 	a := make([]byte, size)
 	b := make([]byte, size)
 	idx := rand.IntN(size)
-	a[idx] = uint8(rand.Uint())
-	b[idx] = uint8(rand.Uint())
+	a[idx] = uint8(rand.Int())
+	b[idx] = uint8(rand.Int())
 	r1 := fancy(a, b)
 	r2 := generic(a, b)
 	if r1 != r2 {

--- a/any_masked_test.go
+++ b/any_masked_test.go
@@ -1,0 +1,78 @@
+package and
+
+import (
+	"math/rand/v2"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func anyMaskedNaive(a, b []byte) bool {
+	for i := range a {
+		if a[i]&b[i] != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func testAgainstBool(t *testing.T, fancy, generic func(a, b []byte) bool, size int) {
+	a := make([]byte, size)
+	b := make([]byte, size)
+	idx := rand.IntN(size)
+	a[idx] = uint8(rand.Uint())
+	b[idx] = uint8(rand.Uint())
+	r1 := fancy(a, b)
+	r2 := generic(a, b)
+	if r1 != r2 {
+		t.Fatalf("%s produced a different result from %s at length %d:\n%t\n%t", runtime.FuncForPC(reflect.ValueOf(fancy).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(generic).Pointer()).Name(), size, r1, r2)
+	}
+}
+
+func TestAnyMasked(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		size := 1 << i
+		testAgainstBool(t, AnyMasked, anyMaskedNaive, size)
+		testAgainstBool(t, anyMaskedGeneric, anyMaskedNaive, size)
+		for j := 0; j < 10; j++ {
+			testAgainstBool(t, AnyMasked, anyMaskedNaive, size+rand.IntN(100))
+			testAgainstBool(t, anyMaskedGeneric, anyMaskedNaive, size+rand.IntN(100))
+		}
+	}
+}
+
+func BenchmarkAnyMasked(b *testing.B) {
+	b.StopTimer()
+	size := 32000
+	a := make([]byte, size)
+	bb := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		AnyMasked(a, bb)
+	}
+}
+
+func BenchmarkAnyMaskedGeneric(b *testing.B) {
+	b.StopTimer()
+	size := 32000
+	a := make([]byte, size)
+	bb := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		anyMaskedGeneric(a, bb)
+	}
+}
+
+func BenchmarkAnyMaskedNaive(b *testing.B) {
+	b.StopTimer()
+	size := 32000
+	a := make([]byte, size)
+	bb := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		anyMaskedNaive(a, bb)
+	}
+}

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,8 +2,9 @@
 
 set -ex
 
-# ^.{2,6}$ is a hack to skip the .+Generic benchmarks
-go test -run=^# -count=10 -bench="^Benchmark.{2,6}$" | tee asm
-go test -run=^# -count=10 -bench="^Benchmark.{2,6}$" -tags purego | tee purego
-go test -run=^# -count=10 -bench="^Benchmark.{2,6}Naive$" | sed --unbuffered 's/Naive//g' | tee naive
+FUNCTIONS="(And|Or|Xor|AndNot|AnySetMasked)"
+
+go test -run=^# -count=10 -bench="^Benchmark${FUNCTIONS}$" | tee asm
+go test -run=^# -count=10 -bench="^Benchmark${FUNCTIONS}$" -tags purego | tee purego
+go test -run=^# -count=10 -bench="^Benchmark${FUNCTIONS}Naive$" | sed --unbuffered 's/Naive//g' | tee naive
 go run golang.org/x/perf/cmd/benchstat@latest naive purego asm

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FUNCTIONS="(And|Or|Xor|AndNot|AnySetMasked)"
+FUNCTIONS="(And|Or|Xor|AndNot|AnyMasked)"
 
 go test -run=^# -count=10 -bench="^Benchmark${FUNCTIONS}$" | tee asm
 go test -run=^# -count=10 -bench="^Benchmark${FUNCTIONS}$" -tags purego | tee purego

--- a/fallback.go
+++ b/fallback.go
@@ -29,3 +29,7 @@ func popcnt(a []byte) int {
 func memset(dst []byte, b byte) {
 	memsetGeneric(dst, b)
 }
+
+func anySetMasked(a, b []byte) bool {
+	return anySetMaskedGeneric(a, b)
+}

--- a/fallback.go
+++ b/fallback.go
@@ -30,6 +30,6 @@ func memset(dst []byte, b byte) {
 	memsetGeneric(dst, b)
 }
 
-func anySetMasked(a, b []byte) bool {
-	return anySetMaskedGeneric(a, b)
+func anyMasked(a, b []byte) bool {
+	return anyMaskedGeneric(a, b)
 }

--- a/internal/asm/go.mod
+++ b/internal/asm/go.mod
@@ -1,10 +1,11 @@
 module github.com/bwesterb/go-and/internal/asm
 
-go 1.22.5
+go 1.24.0
 
 require github.com/mmcloughlin/avo v0.6.0
 
 require (
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/tools v0.16.1 // indirect
+	golang.org/x/mod v0.31.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/tools v0.40.0 // indirect
 )

--- a/internal/asm/go.sum
+++ b/internal/asm/go.sum
@@ -1,8 +1,10 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mmcloughlin/avo v0.6.0 h1:QH6FU8SKoTLaVs80GA8TJuLNkUYl4VokHKlPhVDg4YY=
 github.com/mmcloughlin/avo v0.6.0/go.mod h1:8CoAGaCSYXtCPR+8y18Y9aB/kxb8JSS6FRI7mSkvD+8=
-golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
-golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
-golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
-golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
+golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
+golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
+golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=

--- a/internal/asm/src.go
+++ b/internal/asm/src.go
@@ -25,8 +25,8 @@ func main() {
 	genPopcnt()
 	genMemset(AVX2)
 	genMemset(AVX)
-	genAnySetMasked(AVX2)
-	genAnySetMasked(AVX)
+	genAnyMasked(AVX2) // TODO: 256 bit is already supported on AVX
+	genAnyMasked(AVX)
 	Generate()
 }
 
@@ -226,8 +226,8 @@ func genMemset(avxLevel AVXLevel) {
 	RET()
 }
 
-func genAnySetMasked(avxLevel AVXLevel) {
-	TEXT("anySetMasked"+string(avxLevel), NOSPLIT, "func(a, b *byte, l uint64) bool")
+func genAnyMasked(avxLevel AVXLevel) {
+	TEXT("anyMasked"+string(avxLevel), NOSPLIT, "func(a, b *byte, l uint64) bool")
 
 	Pragma("noescape")
 

--- a/internal/asm/src.go
+++ b/internal/asm/src.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/mmcloughlin/avo/build"
 	. "github.com/mmcloughlin/avo/operand"
-	. "github.com/mmcloughlin/avo/reg"
 )
 
 func main() {
@@ -261,12 +260,16 @@ func genAnyMaskedAVX() {
 	SUBQ(U32(1), l)
 	JNZ(LabelRef("loop"))
 
-	MOVL(U32(0), EAX)
+	ret := GP8()
+
+	XORB(ret, ret) // return false
+	Store(ret, ReturnIndex(0))
 	VZEROALL()
 	RET()
 
 	Label("found")
-	MOVL(U32(1), EAX)
+	MOVB(U8(1), ret) // return true
+	Store(ret, ReturnIndex(0))
 	VZEROALL()
 	RET()
 }

--- a/lib.go
+++ b/lib.go
@@ -187,7 +187,14 @@ func AnyMasked(a, b []byte) bool {
 }
 
 func anyMaskedGeneric(a, b []byte) bool {
-	for i := range a {
+	i := 0
+
+	for ; i <= len(a)-8; i += 8 {
+		if binary.LittleEndian.Uint64(a[i:])&binary.LittleEndian.Uint64(b[i:]) != 0 {
+			return true
+		}
+	}
+	for ; i < len(a); i++ {
 		if a[i]&b[i] != 0 {
 			return true
 		}

--- a/lib.go
+++ b/lib.go
@@ -177,16 +177,16 @@ func memsetGeneric(dst []byte, b byte) {
 	}
 }
 
-// AnySetMasked returns whether at least one of the bits of its arguments AND-ed together is set.
-func AnySetMasked(a, b []byte) bool {
+// AnyMasked returns whether at least one of the bits of its arguments AND-ed together is set.
+func AnyMasked(a, b []byte) bool {
 	if len(a) != len(b) {
 		panic("lengths of a and b must be equal")
 	}
 
-	return anySetMasked(a, b)
+	return anyMasked(a, b)
 }
 
-func anySetMaskedGeneric(a, b []byte) bool {
+func anyMaskedGeneric(a, b []byte) bool {
 	for i := range a {
 		if a[i]&b[i] != 0 {
 			return true

--- a/lib.go
+++ b/lib.go
@@ -176,3 +176,21 @@ func memsetGeneric(dst []byte, b byte) {
 		dst[i] = b
 	}
 }
+
+// AnySetMasked returns whether at least one of the bits of its arguments AND-ed together is set.
+func AnySetMasked(a, b []byte) bool {
+	if len(a) != len(b) {
+		panic("lengths of a and b must be equal")
+	}
+
+	return anySetMasked(a, b)
+}
+
+func anySetMaskedGeneric(a, b []byte) bool {
+	for i := range a {
+		if a[i]&b[i] != 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- [x] Generic implementation
- [x] AVX vectorized implementation for amd64
- [ ] Optimized implementation for arm64

Benchmark results on Intel Core i7-8700 (2 vCPU VPS):

```
goos: linux
goarch: amd64
pkg: github.com/bwesterb/go-and
cpu: Intel Core Processor (Skylake, IBRS)
            │     naive     │                purego                │                 asm                 │
            │    sec/op     │    sec/op     vs base                │   sec/op     vs base                │
And-2         15268.5n ± 1%   5730.0n ± 3%  -62.47% (p=0.000 n=10)   682.0n ± 1%  -95.53% (p=0.000 n=10)
Or-2          15272.5n ± 3%   5768.5n ± 1%  -62.23% (p=0.000 n=10)   677.6n ± 1%  -95.56% (p=0.000 n=10)
Xor-2         15240.5n ± 2%   5762.0n ± 1%  -62.19% (p=0.000 n=10)   655.0n ± 2%  -95.70% (p=0.000 n=10)
AndNot-2      15208.0n ± 1%   6053.0n ± 3%  -60.20% (p=0.000 n=10)   664.6n ± 1%  -95.63% (p=0.000 n=10)
AnyMasked-2    9577.5n ± 2%   3094.0n ± 1%  -67.70% (p=0.000 n=10)   570.4n ± 2%  -94.04% (p=0.000 n=10)
geomean         13.89µ         5.134µ       -63.05%                  648.6n       -95.33%

            │    naive     │                purego                 │                   asm                   │
            │     B/s      │     B/s       vs base                 │      B/s       vs base                  │
And-2         1.952Gi ± 1%   5.201Gi ± 3%  +166.47% (p=0.000 n=10)   43.700Gi ± 1%  +2138.86% (p=0.000 n=10)
Or-2          1.951Gi ± 3%   5.166Gi ± 1%  +164.74% (p=0.000 n=10)   43.979Gi ± 1%  +2153.69% (p=0.000 n=10)
Xor-2         1.955Gi ± 2%   5.172Gi ± 1%  +164.49% (p=0.000 n=10)   45.497Gi ± 1%  +2226.69% (p=0.000 n=10)
AndNot-2      1.960Gi ± 1%   4.923Gi ± 3%  +151.23% (p=0.000 n=10)   44.844Gi ± 1%  +2188.31% (p=0.000 n=10)
AnyMasked-2   3.112Gi ± 2%   9.632Gi ± 1%  +209.55% (p=0.000 n=10)   52.247Gi ± 2%  +1579.08% (p=0.000 n=10)
geomean       2.145Gi        5.805Gi       +170.60%                   45.95Gi       +2042.15%
```