### PR TITLE
Add Any()

### DIFF
--- a/and_amd64.go
+++ b/and_amd64.go
@@ -124,6 +124,18 @@ func memset(dst []byte, b byte) {
 	memsetGeneric(dst[l:], b)
 }
 
+func any_(a []byte) bool {
+	l := uint64(0)
+	if hasAVX() {
+		l = uint64(len(a)) >> 8
+		if l != 0 && anyAVX(&a[0], l) {
+			return true
+		}
+		l <<= 8
+	}
+	return anyGeneric(a[l:])
+}
+
 func anyMasked(a, b []byte) bool {
 	l := uint64(0)
 	if hasAVX() {

--- a/and_amd64.s
+++ b/and_amd64.s
@@ -556,6 +556,51 @@ DATA zeroes<>+8(SB)/4, $0x00000000
 DATA zeroes<>+12(SB)/4, $0x00000000
 GLOBL zeroes<>(SB), RODATA|NOPTR, $16
 
+// func anyAVX(a *byte, l uint64) bool
+// Requires: AVX
+TEXT ·anyAVX(SB), NOSPLIT, $0-17
+	MOVQ a+0(FP), AX
+	MOVQ l+8(FP), CX
+
+loop:
+	VMOVDQU (AX), Y0
+	VMOVDQU 32(AX), Y1
+	VMOVDQU 64(AX), Y2
+	VMOVDQU 96(AX), Y3
+	VMOVDQU 128(AX), Y4
+	VMOVDQU 160(AX), Y5
+	VMOVDQU 192(AX), Y6
+	VMOVDQU 224(AX), Y7
+	VPTEST  Y0, Y0
+	JNZ     found
+	VPTEST  Y1, Y1
+	JNZ     found
+	VPTEST  Y2, Y2
+	JNZ     found
+	VPTEST  Y3, Y3
+	JNZ     found
+	VPTEST  Y4, Y4
+	JNZ     found
+	VPTEST  Y5, Y5
+	JNZ     found
+	VPTEST  Y6, Y6
+	JNZ     found
+	VPTEST  Y7, Y7
+	JNZ     found
+	ADDQ    $0x00000100, AX
+	SUBQ    $0x00000001, CX
+	JNZ     loop
+	XORB    AL, AL
+	MOVB    AL, ret+16(FP)
+	VZEROALL
+	RET
+
+found:
+	MOVB $0x01, AL
+	MOVB AL, ret+16(FP)
+	VZEROALL
+	RET
+
 // func anyMaskedAVX(a *byte, b *byte, l uint64) bool
 // Requires: AVX
 TEXT ·anyMaskedAVX(SB), NOSPLIT, $0-25

--- a/and_arm64.go
+++ b/and_arm64.go
@@ -79,6 +79,11 @@ func memset(dst []byte, b byte) {
 	memsetGeneric(dst[l:], b)
 }
 
+func any_(a []byte) bool {
+	// TODO: Write NEON implementation
+	return anyGeneric(a)
+}
+
 func anyMasked(a, b []byte) bool {
 	// TODO: Write NEON implementation
 	return anyMaskedGeneric(a, b)

--- a/and_stubs_amd64.go
+++ b/and_stubs_amd64.go
@@ -69,6 +69,11 @@ func memsetAVX2(dst *byte, l uint64, b byte)
 //go:noescape
 func memsetAVX(dst *byte, l uint64, b byte)
 
+// Returns whether any of the bits of of a is set
+//
+//go:noescape
+func anyAVX(a *byte, l uint64) bool
+
 // Returns whether any of the bits of the bitwise and of a and b are set assuming all are 256*l bytes
 //
 //go:noescape

--- a/any_test.go
+++ b/any_test.go
@@ -1,0 +1,73 @@
+package and
+
+import (
+	"math/rand/v2"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func anyNaive(a []byte) bool {
+	for _, v := range a {
+		if v != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func testAny(t *testing.T, fancy, generic func(a []byte) bool, size int) {
+	a := make([]byte, size)
+	idx := rand.IntN(size)
+	a[idx] = uint8(rand.Int() & 2)
+	r1 := fancy(a)
+	r2 := generic(a)
+	if r1 != r2 {
+		t.Fatalf("%s produced a different result from %s at length %d:\n%t\n%t", runtime.FuncForPC(reflect.ValueOf(fancy).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(generic).Pointer()).Name(), size, r1, r2)
+	}
+}
+
+func TestAny(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		size := 1 << i
+		testAny(t, Any, anyNaive, size)
+		testAny(t, anyGeneric, anyNaive, size)
+		for j := 0; j < 10; j++ {
+			testAny(t, Any, anyNaive, size+rand.IntN(100))
+			testAny(t, anyGeneric, anyNaive, size+rand.IntN(100))
+		}
+	}
+}
+
+func BenchmarkAny(b *testing.B) {
+	b.StopTimer()
+	size := 32000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		Any(a)
+	}
+}
+
+func BenchmarkAnyGeneric(b *testing.B) {
+	b.StopTimer()
+	size := 32000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		anyGeneric(a)
+	}
+}
+
+func BenchmarkAnyNaive(b *testing.B) {
+	b.StopTimer()
+	size := 32000
+	a := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		anyNaive(a)
+	}
+}

--- a/fallback.go
+++ b/fallback.go
@@ -30,6 +30,10 @@ func memset(dst []byte, b byte) {
 	memsetGeneric(dst, b)
 }
 
+func any_(a []byte) bool {
+	return anyGeneric(a)
+}
+
 func anyMasked(a, b []byte) bool {
 	return anyMaskedGeneric(a, b)
 }

--- a/lib.go
+++ b/lib.go
@@ -177,6 +177,27 @@ func memsetGeneric(dst []byte, b byte) {
 	}
 }
 
+// Any returns whether at least one bit is set.
+func Any(a []byte) bool {
+	return any_(a)
+}
+
+func anyGeneric(a []byte) bool {
+	i := 0
+
+	for ; i <= len(a)-8; i += 8 {
+		if binary.LittleEndian.Uint64(a[i:]) != 0 {
+			return true
+		}
+	}
+	for ; i < len(a); i++ {
+		if a[i] != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // AnyMasked returns whether at least one of the bits of its arguments AND-ed together is set.
 func AnyMasked(a, b []byte) bool {
 	if len(a) != len(b) {


### PR DESCRIPTION
```
BenchmarkAny-32                          5734298               206.4 ns/op      155002.17 MB/s
BenchmarkAnyGeneric-32                    840888              1431 ns/op        22368.76 MB/s
BenchmarkAnyNaive-32                      190646              5677 ns/op        5637.10 MB/s
BenchmarkAnyWithMasked-32                4240680               282.5 ns/op      113257.51 MB/s
BenchmarkAnyGenericWithMasked-32          788074              1422 ns/op        22506.90 MB/s
BenchmarkAnyNaiveWithMasked-32            177759              5831 ns/op        5488.36 MB/s
PASS
```